### PR TITLE
Adding a default value for the "getArrowStyle()" param

### DIFF
--- a/src/NextStep.tsx
+++ b/src/NextStep.tsx
@@ -356,7 +356,7 @@ const NextStep: React.FC<NextStepProps> = ({
 
   // - -
   // Check if Card is Cut Off on Sides
-  const checkSideCutOff = (side: string) => {
+  const checkSideCutOff = (side: string = 'right') => {
     let tempSide = side;
 
     let removeSide = false;

--- a/src/NextStep.tsx
+++ b/src/NextStep.tsx
@@ -356,7 +356,7 @@ const NextStep: React.FC<NextStepProps> = ({
 
   // - -
   // Check if Card is Cut Off on Sides
-  const checkSideCutOff = (side: string = 'right') => {
+  const checkSideCutOff = (side: string) => {
     let tempSide = side;
 
     let removeSide = false;
@@ -487,7 +487,7 @@ const NextStep: React.FC<NextStepProps> = ({
 
   // - -
   // Arrow position based on card side
-  const getArrowStyle = (side: string) => {
+  const getArrowStyle = (side: string = 'right') => {
     side = checkSideCutOff(side);
 
     switch (side) {


### PR DESCRIPTION
When defining steps for a tour, if a step does not have the optional "side" property defined.... the call to `checkSideCutOff()` contains undefined and makes the function call fail.

Specifically what fails within the `<CardArrow />` component, when it calls `getArrowStyle()`.
`getArrowStyle(currentTourSteps?.[currentStep]?.side)`

So that passes a value of `undefined` all the way down the following chain of functions.
CardArrow --> getArrowStyle --> checkSideCutOff

The idea is that by setting a default value to the `getArrowStyle()`, that will protect against undefined values when this property is not defined in the step.