### PR TITLE
add noInViewScroll to NextStep props

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,23 +367,24 @@ Here's an example of how to use `NextStepViewport`:
 
 ### NextStep Props
 
-| Property              | Type                                               | Description                                                                            |
-| --------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `children`            | `React.ReactNode`                                  | Your website or application content                                                    |
-| `steps`               | `Array[]`                                          | Array of Tour objects defining each step of the onboarding                             |
-| `navigationAdapter`   | `NavigationAdapter`                                | Optional. Router adapter for navigation (defaults to Next.js)                          |
-| `showNextStep`        | `boolean`                                          | Controls visibility of the onboarding overlay                                          |
-| `shadowRgb`           | `string`                                           | RGB values for the shadow color surrounding the target area                            |
-| `shadowOpacity`       | `string`                                           | Opacity value for the shadow surrounding the target area                               |
-| `cardComponent`       | `React.ComponentType`                              | Custom card component to replace the default one                                       |
-| `cardTransition`      | `Transition`                                       | Motion transition object for step transitions                                          |
-| `onStart`             | `(tourName: string \| null) => void`               | Callback function triggered when the tour starts                                       |
-| `onStepChange`        | `(step: number, tourName: string \| null) => void` | Callback function triggered when the step changes                                      |
-| `onComplete`          | `(tourName: string \| null) => void`               | Callback function triggered when the tour completes                                    |
-| `onSkip`              | `(step: number, tourName: string \| null) => void` | Callback function triggered when the user skips the tour                               |
-| `clickThroughOverlay` | `boolean`                                          | Optional. If true, overlay background is clickable, default is false                   |
-| `disableConsoleLogs`  | `boolean`                                          | Optional. If true, console logs are disabled, default is false                         |
-| `scrollToTop`         | `boolean`                                          | Optional. If true, the page will scroll to the top when the tour ends, default is true |
+| Property              | Type                                               | Description                                                                                            |
+| --------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `children`            | `React.ReactNode`                                  | Your website or application content                                                                    |
+| `steps`               | `Array[]`                                          | Array of Tour objects defining each step of the onboarding                                             |
+| `navigationAdapter`   | `NavigationAdapter`                                | Optional. Router adapter for navigation (defaults to Next.js)                                          |
+| `showNextStep`        | `boolean`                                          | Controls visibility of the onboarding overlay                                                          |
+| `shadowRgb`           | `string`                                           | RGB values for the shadow color surrounding the target area                                            |
+| `shadowOpacity`       | `string`                                           | Opacity value for the shadow surrounding the target area                                               |
+| `cardComponent`       | `React.ComponentType`                              | Custom card component to replace the default one                                                       |
+| `cardTransition`      | `Transition`                                       | Motion transition object for step transitions                                                          |
+| `onStart`             | `(tourName: string \| null) => void`               | Callback function triggered when the tour starts                                                       |
+| `onStepChange`        | `(step: number, tourName: string \| null) => void` | Callback function triggered when the step changes                                                      |
+| `onComplete`          | `(tourName: string \| null) => void`               | Callback function triggered when the tour completes                                                    |
+| `onSkip`              | `(step: number, tourName: string \| null) => void` | Callback function triggered when the user skips the tour                                               |
+| `clickThroughOverlay` | `boolean`                                          | Optional. If true, overlay background is clickable, default is false                                   |
+| `disableConsoleLogs`  | `boolean`                                          | Optional. If true, console logs are disabled, default is false                                         |
+| `scrollToTop`         | `boolean`                                          | Optional. If true, the page will scroll to the top when the tour ends, default is true                 |
+| `noInViewScroll`      | `boolean`                                          | Optional. If true, the page will not scroll to the target element when it is in view, default is false |
 
 ```tsx
 <NextStep

--- a/dist/NextStep.js
+++ b/dist/NextStep.js
@@ -6,7 +6,7 @@ import { motion, useInView } from 'motion/react';
 import { useWindowAdapter } from './adapters/window';
 import DefaultCard from './DefaultCard';
 import DynamicPortal from './DynamicPortal';
-const NextStep = ({ children, steps, shadowRgb = '0, 0, 0', shadowOpacity = '0.2', cardTransition = { ease: 'anticipate', duration: 0.6 }, cardComponent: CardComponent, onStart = () => { }, onStepChange = () => { }, onComplete = () => { }, onSkip = () => { }, displayArrow = true, clickThroughOverlay = false, navigationAdapter = useWindowAdapter, disableConsoleLogs = false, scrollToTop = true, }) => {
+const NextStep = ({ children, steps, shadowRgb = '0, 0, 0', shadowOpacity = '0.2', cardTransition = { ease: 'anticipate', duration: 0.6 }, cardComponent: CardComponent, onStart = () => { }, onStepChange = () => { }, onComplete = () => { }, onSkip = () => { }, displayArrow = true, clickThroughOverlay = false, navigationAdapter = useWindowAdapter, disableConsoleLogs = false, scrollToTop = true, noInViewScroll = false, }) => {
     const { currentTour, currentStep, setCurrentStep, isNextStepVisible, closeNextStep } = useNextStep();
     const currentTourSteps = steps.find((tour) => tour.tour === currentTour)?.steps;
     const [elementToScroll, setElementToScroll] = useState(null);
@@ -78,7 +78,7 @@ const NextStep = ({ children, steps, shadowRgb = '0, 0, 0', shadowOpacity = '0.2
                     setElementToScroll(element);
                     const rect = element.getBoundingClientRect();
                     const isInViewportWithOffset = rect.top >= -offset && rect.bottom <= window.innerHeight + offset;
-                    if (!isInView || !isInViewportWithOffset) {
+                    if (!isInViewportWithOffset) {
                         const side = checkSideCutOff(currentTourSteps?.[currentStep]?.side || 'right');
                         element.scrollIntoView({
                             behavior: 'smooth',
@@ -206,7 +206,7 @@ const NextStep = ({ children, steps, shadowRgb = '0, 0, 0', shadowOpacity = '0.2
                     setElementToScroll(element);
                     const rect = element.getBoundingClientRect();
                     const isInViewportWithOffset = rect.top >= -offset && rect.bottom <= window.innerHeight + offset;
-                    if (!isInView || !isInViewportWithOffset) {
+                    if (!isInViewportWithOffset) {
                         const side = checkSideCutOff(currentTourSteps?.[currentStep]?.side || 'right');
                         element.scrollIntoView({
                             behavior: 'smooth',
@@ -248,15 +248,17 @@ const NextStep = ({ children, steps, shadowRgb = '0, 0, 0', shadowOpacity = '0.2
                 console.log('NextStep: Element to Scroll Changed');
             }
             const side = checkSideCutOff(currentTourSteps?.[currentStep]?.side || 'right');
-            elementToScroll.scrollIntoView({
-                behavior: 'smooth',
-                block: side.includes('top')
-                    ? 'end'
-                    : side.includes('bottom')
-                        ? 'start'
-                        : 'center',
-                inline: 'center',
-            });
+            if (!noInViewScroll) {
+                elementToScroll.scrollIntoView({
+                    behavior: 'smooth',
+                    block: side.includes('top')
+                        ? 'end'
+                        : side.includes('bottom')
+                            ? 'start'
+                            : 'center',
+                    inline: 'center',
+                });
+            }
         }
         else {
             if (scrollToTop || !elementToScroll) {

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -44,6 +44,7 @@ export interface NextStepProps {
     navigationAdapter?: () => NavigationAdapter;
     disableConsoleLogs?: boolean;
     scrollToTop?: boolean;
+    noInViewScroll?: boolean;
 }
 export interface CardComponentProps {
     step: Step;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextstepjs",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Lightweight onboarding library for Next.js",
   "license": "MIT",
   "author": "Alex Enes Zorlu",

--- a/src/NextStep.tsx
+++ b/src/NextStep.tsx
@@ -25,6 +25,7 @@ const NextStep: React.FC<NextStepProps> = ({
   navigationAdapter = useWindowAdapter,
   disableConsoleLogs = false,
   scrollToTop = true,
+  noInViewScroll = false,
 }) => {
   const { currentTour, currentStep, setCurrentStep, isNextStepVisible, closeNextStep } =
     useNextStep();
@@ -120,7 +121,7 @@ const NextStep: React.FC<NextStepProps> = ({
           const isInViewportWithOffset =
             rect.top >= -offset && rect.bottom <= window.innerHeight + offset;
 
-          if (!isInView || !isInViewportWithOffset) {
+          if (!isInViewportWithOffset) {
             const side = checkSideCutOff(
               currentTourSteps?.[currentStep]?.side || 'right',
             );
@@ -267,7 +268,7 @@ const NextStep: React.FC<NextStepProps> = ({
           const isInViewportWithOffset =
             rect.top >= -offset && rect.bottom <= window.innerHeight + offset;
 
-          if (!isInView || !isInViewportWithOffset) {
+          if (!isInViewportWithOffset) {
             const side = checkSideCutOff(
               currentTourSteps?.[currentStep]?.side || 'right',
             );
@@ -312,15 +313,17 @@ const NextStep: React.FC<NextStepProps> = ({
       }
 
       const side = checkSideCutOff(currentTourSteps?.[currentStep]?.side || 'right');
-      elementToScroll.scrollIntoView({
-        behavior: 'smooth',
-        block: side.includes('top')
-          ? 'end'
-          : side.includes('bottom')
-          ? 'start'
-          : 'center',
-        inline: 'center',
-      });
+      if (!noInViewScroll) {
+        elementToScroll.scrollIntoView({
+          behavior: 'smooth',
+          block: side.includes('top')
+            ? 'end'
+            : side.includes('bottom')
+            ? 'start'
+            : 'center',
+          inline: 'center',
+        });
+      }
     } else {
       if (scrollToTop || !elementToScroll) {
         // Scroll to the top of the body

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,7 @@ export interface NextStepProps {
   navigationAdapter?: () => NavigationAdapter;
   disableConsoleLogs?: boolean;
   scrollToTop?: boolean;
+  noInViewScroll?: boolean;
 }
 
 // Custom Card


### PR DESCRIPTION
noInViewScroll is added to NextStep props. #8 


| `noInViewScroll`      | `boolean`     | Optional. If true, the page will not scroll to the target element when it is in view, default is false |