### PR TITLE
Implement SmoothSpotlight to avoid gpu issues in google chrome and im…

### DIFF
--- a/dist/NextStepReact.js
+++ b/dist/NextStepReact.js
@@ -6,6 +6,7 @@ import { motion, useInView } from 'motion/react';
 import { useWindowAdapter } from './adapters/window';
 import DefaultCard from './DefaultCard';
 import DynamicPortal from './DynamicPortal';
+import SmoothSpotlight from './SmoothSpotlight';
 /**
  * NextStepReact component for rendering the onboarding steps.
  *
@@ -846,10 +847,9 @@ const NextStepReact = ({ children, steps, shadowRgb = '0, 0, 0', shadowOpacity =
                                         left: `${pointerPosition.x + pointerPosition.width + pointerPadOffset}px`,
                                         right: 0,
                                         height: viewportRect.height,
-                                    } })] })), _jsx(motion.div, { "data-name": "nextstep-pointer", style: {
+                                    } })] })), _jsx(SmoothSpotlight, { x: pointerPosition.x - pointerPadOffset, y: pointerPosition.y - pointerPadOffset, width: pointerPosition.width + pointerPadding, height: pointerPosition.height + pointerPadding, padding: pointerPadding, radius: pointerRadius, shadowOpacity: shadowOpacity, shadowRgb: shadowRgb }), _jsx(motion.div, { "data-name": "nextstep-pointer", style: {
                                 position: 'relative',
                                 zIndex: 999,
-                                boxShadow: `0 0 200vw 9999vh rgba(${shadowRgb}, ${shadowOpacity})`,
                                 borderRadius: `${pointerRadius}px ${pointerRadius}px ${pointerRadius}px ${pointerRadius}px`,
                                 pointerEvents: 'none',
                             }, initial: pointerPosition

--- a/dist/SmoothSpotlight.d.ts
+++ b/dist/SmoothSpotlight.d.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+interface SmoothSpotlightProps {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    padding: number;
+    radius: number;
+    shadowOpacity: string;
+    shadowRgb: string;
+}
+declare const SmoothSpotlight: React.FC<SmoothSpotlightProps>;
+export default SmoothSpotlight;

--- a/dist/SmoothSpotlight.js
+++ b/dist/SmoothSpotlight.js
@@ -1,0 +1,22 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { motion } from 'motion/react';
+const SmoothSpotlight = ({ x, y, width, height, padding, radius, shadowOpacity, shadowRgb, }) => {
+    const px = x - padding / 2;
+    const py = y - padding / 2;
+    const pw = width + padding;
+    const ph = height + padding;
+    return (_jsx("div", { style: {
+            position: 'absolute',
+            inset: 0,
+            zIndex: 998,
+            pointerEvents: 'none',
+        }, children: _jsxs("svg", { width: "100%", height: "100%", children: [_jsx("defs", { children: _jsxs("mask", { id: "smooth-spotlight-mask", children: [_jsx("rect", { width: "100%", height: "100%", fill: "white" }), _jsx(motion.rect, { initial: false, animate: {
+                                    x: px,
+                                    y: py,
+                                    width: pw,
+                                    height: ph,
+                                    rx: radius,
+                                    ry: radius,
+                                }, transition: { duration: 0.4, ease: 'easeInOut' }, fill: "black" })] }) }), _jsx("rect", { width: "100%", height: "100%", fill: `rgba(${shadowRgb}, ${shadowOpacity})`, mask: "url(#smooth-spotlight-mask)" })] }) }));
+};
+export default SmoothSpotlight;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextstepjs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Lightweight onboarding library for Next.js",
   "license": "MIT",
   "author": "Alex Enes Zorlu",

--- a/src/NextStepReact.tsx
+++ b/src/NextStepReact.tsx
@@ -8,6 +8,7 @@ import { useWindowAdapter } from './adapters/window';
 import { NextStepProps } from './types';
 import DefaultCard from './DefaultCard';
 import DynamicPortal from './DynamicPortal';
+import SmoothSpotlight from './SmoothSpotlight';
 
 /**
  * NextStepReact component for rendering the onboarding steps.
@@ -1025,13 +1026,22 @@ const NextStepReact: React.FC<NextStepProps> = ({
               </div>
             )}
 
+            <SmoothSpotlight
+              x={pointerPosition.x - pointerPadOffset}
+              y={pointerPosition.y - pointerPadOffset}
+              width={pointerPosition.width + pointerPadding}
+              height={pointerPosition.height + pointerPadding}
+              padding={pointerPadding}
+              radius={pointerRadius}
+              shadowOpacity={shadowOpacity}
+              shadowRgb={shadowRgb}
+            />
             {/* Pointer */}
             <motion.div
               data-name="nextstep-pointer"
               style={{
                 position: 'relative',
                 zIndex: 999,
-                boxShadow: `0 0 200vw 9999vh rgba(${shadowRgb}, ${shadowOpacity})`,
                 borderRadius: `${pointerRadius}px ${pointerRadius}px ${pointerRadius}px ${pointerRadius}px`,
                 pointerEvents: 'none',
               }}

--- a/src/SmoothSpotlight.tsx
+++ b/src/SmoothSpotlight.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { motion } from 'motion/react';
+
+// special thanks to https://github.com/enszrlu/NextStep/issues/32 @dinamicby
+
+interface SmoothSpotlightProps {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  padding: number;
+  radius: number;
+  shadowOpacity: string;
+  shadowRgb: string;
+}
+
+const SmoothSpotlight: React.FC<SmoothSpotlightProps> = ({
+  x,
+  y,
+  width,
+  height,
+  padding,
+  radius,
+  shadowOpacity,
+  shadowRgb,
+}) => {
+  const px = x - padding / 2;
+  const py = y - padding / 2;
+  const pw = width + padding;
+  const ph = height + padding;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 998,
+        pointerEvents: 'none',
+      }}
+    >
+      <svg width="100%" height="100%">
+        <defs>
+          <mask id="smooth-spotlight-mask">
+            <rect width="100%" height="100%" fill="white" />
+            <motion.rect
+              initial={false}
+              animate={{
+                x: px,
+                y: py,
+                width: pw,
+                height: ph,
+                rx: radius,
+                ry: radius,
+              }}
+              transition={{ duration: 0.4, ease: 'easeInOut' }}
+              fill="black"
+            />
+          </mask>
+        </defs>
+        <rect
+          width="100%"
+          height="100%"
+          fill={`rgba(${shadowRgb}, ${shadowOpacity})`}
+          mask="url(#smooth-spotlight-mask)"
+        />
+      </svg>
+    </div>
+  );
+};
+
+export default SmoothSpotlight;


### PR DESCRIPTION
Implement SmoothSpotlight to avoid GPU slowdown in Google Chrome and improve performance.
The latest Google Chrome updates caused a massive slowdown in the app with box-shadow. This fixes the issue. 

Use SVG instead of box-shadow. 
#32 
