### PR TITLE
feat: add selector retry mechanism for async-rendered elements

### DIFF
--- a/src/NextStepReact.tsx
+++ b/src/NextStepReact.tsx
@@ -10,6 +10,10 @@ import DefaultCard from './DefaultCard';
 import DynamicPortal from './DynamicPortal';
 import SmoothSpotlight from './SmoothSpotlight';
 
+// Default retry settings for selector lookup
+const DEFAULT_SELECTOR_RETRY_ATTEMPTS = 3;
+const DEFAULT_SELECTOR_RETRY_DELAY_MS = 200;
+
 /**
  * NextStepReact component for rendering the onboarding steps.
  *
@@ -268,6 +272,9 @@ const NextStepReact: React.FC<NextStepProps> = ({
   // - -
   // Update pointerPosition when currentStep changes
   useEffect(() => {
+    // Cleanup function for retry timeouts
+    let cleanupRetries = () => {};
+
     if (isNextStepVisible && currentTourSteps) {
       if (!disableConsoleLogs) {
         console.log('NextStep: Current Step Changed');
@@ -293,8 +300,21 @@ const NextStepReact: React.FC<NextStepProps> = ({
       setScrollableParent(getScrollableParent(tempViewport));
 
       if (step && step.selector) {
-        const element = document.querySelector(step.selector) as Element | null;
-        if (element) {
+        // Track retry state
+        const retryTimeouts: number[] = [];
+        let cancelled = false;
+
+        // Get retry configuration from step or use defaults
+        const maxAttempts = Math.max(
+          step.selectorRetryAttempts ?? DEFAULT_SELECTOR_RETRY_ATTEMPTS,
+          DEFAULT_SELECTOR_RETRY_ATTEMPTS,
+        );
+        const retryDelay = step.selectorRetryDelay ?? DEFAULT_SELECTOR_RETRY_DELAY_MS;
+
+        // Handler for when element is successfully located
+        const handleElementLocated = (element: Element) => {
+          if (cancelled) return;
+
           setPointerPosition(getElementPosition(element));
           currentElementRef.current = element;
           setElementToScroll(element);
@@ -316,7 +336,38 @@ const NextStepReact: React.FC<NextStepProps> = ({
                 : 'center',
             });
           }
-        }
+        };
+
+        // Recursive function to attempt selector lookup with retries
+        const attemptLookup = (remainingAttempts: number) => {
+          if (cancelled) return;
+
+          const element = document.querySelector(step.selector!) as Element | null;
+          if (element) {
+            handleElementLocated(element);
+            return;
+          }
+
+          // Schedule retry if we have attempts remaining
+          if (remainingAttempts > 0) {
+            const timeoutId = window.setTimeout(
+              () => attemptLookup(remainingAttempts - 1),
+              retryDelay,
+            );
+            retryTimeouts.push(timeoutId);
+          }
+        };
+
+        // Start the lookup process
+        attemptLookup(maxAttempts);
+
+        // Setup cleanup to cancel pending retries
+        cleanupRetries = () => {
+          cancelled = true;
+          retryTimeouts.forEach((timeoutId) => {
+            window.clearTimeout(timeoutId);
+          });
+        };
       } else {
         // Reset pointer position to middle of the screen when selector is empty, undefined, or ""
         if (step.viewportID) {
@@ -339,6 +390,11 @@ const NextStepReact: React.FC<NextStepProps> = ({
         setElementToScroll(null);
       }
     }
+
+    // Cleanup function to cancel pending retries on unmount or step change
+    return () => {
+      cleanupRetries();
+    };
   }, [currentStep, currentTourSteps, isInView, offset, isNextStepVisible]);
 
   useEffect(() => {

--- a/src/NextStepReact.tsx
+++ b/src/NextStepReact.tsx
@@ -10,7 +10,6 @@ import DefaultCard from './DefaultCard';
 import DynamicPortal from './DynamicPortal';
 import SmoothSpotlight from './SmoothSpotlight';
 
-// Default retry settings for selector lookup
 const DEFAULT_SELECTOR_RETRY_ATTEMPTS = 3;
 const DEFAULT_SELECTOR_RETRY_DELAY_MS = 200;
 
@@ -348,7 +347,6 @@ const NextStepReact: React.FC<NextStepProps> = ({
             return;
           }
 
-          // Schedule retry if we have attempts remaining
           if (remainingAttempts > 0) {
             const timeoutId = window.setTimeout(
               () => attemptLookup(remainingAttempts - 1),
@@ -358,7 +356,6 @@ const NextStepReact: React.FC<NextStepProps> = ({
           }
         };
 
-        // Start the lookup process
         attemptLookup(maxAttempts);
 
         // Setup cleanup to cancel pending retries

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,18 @@ export interface Step {
   prevRoute?: string;
   // Dynamic Portal
   viewportID?: string;
+  // Selector retry options (for async-rendered elements)
+  /**
+   * Number of retry attempts when the selector element is not immediately found.
+   * Useful for elements that render asynchronously.
+   * @default 3
+   */
+  selectorRetryAttempts?: number;
+  /**
+   * Delay in milliseconds between selector retry attempts.
+   * @default 200
+   */
+  selectorRetryDelay?: number;
 }
 
 // Tour


### PR DESCRIPTION
## Summary

When targeting elements that render asynchronously (due to React suspense, lazy loading, animations, or data fetching), the selector lookup may fail because the element doesn't exist in the DOM yet.

This PR adds configurable retry logic to handle these cases gracefully.

## Changes

### New Step Options

- `selectorRetryAttempts`: Number of retry attempts when selector is not found (default: 3)
- `selectorRetryDelay`: Delay in milliseconds between retries (default: 200ms)

### Behavior

The retry mechanism:
1. Attempts to find the element immediately
2. If not found, retries up to the configured number of attempts with configurable delay
3. Properly cleans up pending retries on unmount or step change
4. Cancels retries immediately if the element is found

## Use Cases

This is particularly useful for:
- Elements rendered after async data fetching
- Lazy-loaded components
- Elements that appear after animations complete
- Dynamically rendered content in SPAs (Next.js, React Router, etc.)

## Example Usage

```tsx
const steps = [
  {
    tour: 'onboarding',
    steps: [
      {
        selector: '#async-loaded-component',
        title: 'Welcome!',
        content: 'This element loads after data fetching',
        selectorRetryAttempts: 10,  // Try up to 10 times
        selectorRetryDelay: 100,    // Wait 100ms between attempts
      },
    ],
  },
];
```

## Related Issues

Closes #29 - "Next step not rendering"
Related to #52 - "Page glitching on startNextStep with async method or based on state"

## Breaking Changes

None - this is fully backwards compatible. The retry mechanism uses sensible defaults that maintain existing behavior while adding resilience for async scenarios.

## Notes

We tested this code in our repo (https://github.com/agenta-ai/agenta) and it is working fine. 