### PR TITLE
feat: beta improvements (cardOffset, scrollOffset, selector retry, side-swap, custom arrow, caret alignment, optional icon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,32 @@ export const CustomCard = ({
 };
 ```
 
+### Custom Arrow
+
+By default NextStep renders a small SVG caret pointing from the card to the highlighted element. You can recolor/resize it with `arrowStyle`, or replace it entirely with `arrowComponent`. Both are provider-level props and fully optional (omit them for the default arrow).
+
+```tsx
+import { NextStep } from 'nextstepjs';
+import type { ArrowComponentProps } from 'nextstepjs';
+
+// Tweak the built-in caret:
+<NextStep steps={steps} arrowStyle={{ color: '#6d28d9' }}>
+  {children}
+</NextStep>;
+
+// Or fully replace it. Spread the provided `style` so it stays anchored to the card,
+// and use `side` (the resolved placement, after any cut-off adjustment) to orient it:
+const MyArrow = ({ side, style }: ArrowComponentProps) => (
+  <div style={{ ...style }} data-side={side}>
+    ◆
+  </div>
+);
+
+<NextStep steps={steps} arrowComponent={MyArrow}>
+  {children}
+</NextStep>;
+```
+
 ### Tours Array
 
 NextStep supports multiple "tours", allowing you to create multiple product tours:
@@ -277,24 +303,28 @@ const steps: Tour[] = [
 
 ### Step Object
 
-| Prop                   | Type                                     | Description                                                                                                                                         |
-| ---------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `icon`                 | `React.ReactNode`, `string`, `null`      | An icon or element to display alongside the step title.                                                                                             |
-| `title`                | `string`                                 | The title of your step                                                                                                                              |
-| `content`              | `React.ReactNode`                        | The main content or body of the step.                                                                                                               |
-| `selector`             | `string`                                 | Optional. A string used to target an `id` that this step refers to. If not provided, card will be displayed in the center top of the document body. |
-| `side`                 | `"top"`, `"bottom"`, `"left"`, `"right"` | Optional. Determines where the tooltip should appear relative to the selector.                                                                      |
-| `showControls`         | `boolean`                                | Optional. Determines whether control buttons (next, prev) should be shown if using the default card.                                                |
-| `showSkip`             | `boolean`                                | Optional. Determines whether skip button should be shown if using the default card.                                                                 |
-| `blockKeyboardControl` | `boolean`                                | Optional. Determines whether keyboard control should be blocked                                                                                     |
-| `pointerPadding`       | `number`                                 | Optional. The padding around the pointer (keyhole) highlighting the target element.                                                                 |
-| `pointerRadius`        | `number`                                 | Optional. The border-radius of the pointer (keyhole) highlighting the target element.                                                               |
-| `disableInteraction`   | `boolean`                                | Optional. If true, prevents interaction with the highlighted element (default: false).                                                              |
-| `nextRoute`            | `string`                                 | Optional. The route to navigate to when moving to the next step.                                                                                    |
-| `prevRoute`            | `string`                                 | Optional. The route to navigate to when moving to the previous step.                                                                                |
-| `viewportID`           | `string`                                 | Optional. The id of the viewport element to use for positioning. If not provided, the document body will be used.                                   |
+| Prop                    | Type                                                                            | Description                                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `icon`                  | `React.ReactNode`, `string`, `null`                                             | Optional. An icon or element to display alongside the step title (used by the default card).                                                                        |
+| `title`                 | `string`                                                                        | The title of your step                                                                                                                                              |
+| `content`               | `React.ReactNode`                                                               | The main content or body of the step.                                                                                                                              |
+| `selector`              | `string`                                                                        | Optional. A string used to target an `id` that this step refers to. If not provided, card will be displayed in the center top of the document body.                 |
+| `side`                  | `"top"`, `"bottom"`, `"left"`, `"right"` (+ corner variants, e.g. `"top-left"`) | Optional. Determines where the tooltip should appear relative to the selector.                                                                                      |
+| `showControls`          | `boolean`                                                                       | Optional. Determines whether control buttons (next, prev) should be shown if using the default card. Ignored when a custom `cardComponent` is provided.            |
+| `showSkip`              | `boolean`                                                                       | Optional. Determines whether skip button should be shown if using the default card. Ignored when a custom `cardComponent` is provided.                             |
+| `blockKeyboardControl`  | `boolean`                                                                       | Optional. Determines whether keyboard control should be blocked                                                                                                    |
+| `pointerPadding`        | `number`                                                                        | Optional. The padding around the pointer (keyhole) highlighting the target element.                                                                                |
+| `pointerRadius`         | `number`                                                                        | Optional. The border-radius of the pointer (keyhole) highlighting the target element.                                                                              |
+| `cardOffset`            | `number`                                                                        | Optional. Gap in pixels between the card and the spotlight highlight; the caret scales with it too (default: 25).                                                   |
+| `scrollOffset`          | `number`                                                                        | Optional. Extra clearance in pixels kept above/below the target when it is scrolled into view — useful when a fixed/sticky header would cover it (default: 0).      |
+| `selectorRetryAttempts` | `number`                                                                        | Optional. Extra attempts to find `selector` when it is missing on the first lookup (for asynchronously rendered targets). `0` keeps the single-lookup behavior (default: 0). |
+| `selectorRetryDelay`    | `number`                                                                        | Optional. Delay in milliseconds between selector retry attempts (default: 200).                                                                                    |
+| `disableInteraction`    | `boolean`                                                                       | Optional. If true, prevents interaction with the highlighted element (default: false).                                                                             |
+| `nextRoute`             | `string`                                                                        | Optional. The route to navigate to when moving to the next step.                                                                                                   |
+| `prevRoute`             | `string`                                                                        | Optional. The route to navigate to when moving to the previous step.                                                                                               |
+| `viewportID`            | `string`                                                                        | Optional. The id of the viewport element to use for positioning. If not provided, the document body will be used.                                                  |
 
-> **Note** `NextStep` handles card cutoff from screen sides. If side is right or left and card is out of the viewport, side would be switched to `top`. If side is top or bottom and card is out of the viewport, then side would be flipped between top and bottom.
+> **Note** `NextStep` handles card cutoff from screen sides. When the requested side does not have room, NextStep verifies the destination side actually has space before flipping, and otherwise falls back to the side with the most room — so the card stays on-screen instead of swapping into another cramped edge.
 
 ### Target Anything
 
@@ -401,6 +431,10 @@ Here's an example of how to use `NextStepViewport`:
 | `scrollToTop`         | `boolean`                                          | Optional. If true, the page will scroll to the top when the tour ends, default is true                          |
 | `noInViewScroll`      | `boolean`                                          | Optional. If true, the page will not scroll to the target element when it is in view, default is false          |
 | `overlayZIndex`       | `number`                                           | Optional. Base z-index for overlay elements, useful for compatibility with UI libraries like MUI (default: 999) |
+| `arrowComponent`      | `React.ComponentType<ArrowComponentProps>`         | Optional. Render a fully custom arrow/caret. Receives the resolved `side` and the computed positioning `style`. When omitted, the built-in SVG arrow is used.     |
+| `arrowStyle`          | `React.CSSProperties`                              | Optional. Styles merged into the built-in arrow SVG (ignored when `arrowComponent` is set). Handy for tweaking the caret color or size.                          |
+
+> **Note** When a custom `cardComponent` is provided, the per-step `showControls` / `showSkip` options only affect the built-in card, so they are ignored (and TypeScript omits them from the step type). Your custom card renders its own controls.
 
 ```tsx
 <NextStep

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextstepjs",
-  "version": "2.2.0",
+  "version": "2.3.0-beta.0",
   "description": "Lightweight onboarding library for Next.js",
   "license": "MIT",
   "author": "Alex Enes Zorlu",

--- a/src/NextStep.tsx
+++ b/src/NextStep.tsx
@@ -32,44 +32,13 @@ import { useNextAdapter } from './adapters/next';
  * @returns {JSX.Element} The rendered NextStep component.
  *
  */
-const NextStep: React.FC<NextStepProps> = ({
-  children,
-  steps,
-  shadowRgb = '0, 0, 0',
-  shadowOpacity = '0.2',
-  cardTransition = { ease: 'anticipate', duration: 0.6 },
-  cardComponent: CardComponent,
-  onStart = () => {},
-  onStepChange = () => {},
-  onComplete = () => {},
-  onSkip = () => {},
-  displayArrow = true,
-  clickThroughOverlay = false,
-  navigationAdapter = useNextAdapter,
-  disableConsoleLogs = false,
-  scrollToTop = true,
-  noInViewScroll = false,
-  overlayZIndex = 999,
-}) => {
+const NextStep: React.FC<NextStepProps> = (props) => {
+  // Forward every prop to NextStepReact, defaulting the navigation adapter to the
+  // Next.js one. Remaining defaults are applied by NextStepReact itself.
   return (
     <NextStepReact
-      children={children}
-      steps={steps}
-      shadowRgb={shadowRgb}
-      shadowOpacity={shadowOpacity}
-      cardTransition={cardTransition}
-      cardComponent={CardComponent}
-      onStart={onStart}
-      onStepChange={onStepChange}
-      onComplete={onComplete}
-      onSkip={onSkip}
-      displayArrow={displayArrow}
-      clickThroughOverlay={clickThroughOverlay}
-      navigationAdapter={navigationAdapter}
-      disableConsoleLogs={disableConsoleLogs}
-      scrollToTop={scrollToTop}
-      noInViewScroll={noInViewScroll}
-      overlayZIndex={overlayZIndex}
+      {...props}
+      navigationAdapter={props.navigationAdapter ?? useNextAdapter}
     />
   );
 };

--- a/src/NextStepReact.tsx
+++ b/src/NextStepReact.tsx
@@ -5,10 +5,15 @@ import { motion, useInView } from 'motion/react';
 import { useWindowAdapter } from './adapters/window';
 
 // Types
-import { NextStepProps } from './types';
+import { NextStepProps, Tour } from './types';
 import DefaultCard from './DefaultCard';
 import DynamicPortal from './DynamicPortal';
 import SmoothSpotlight from './SmoothSpotlight';
+
+/** Default gap (px) between the tour card and the spotlight highlight. */
+const DEFAULT_CARD_OFFSET = 25;
+/** Default delay (ms) between selector retry attempts. */
+const DEFAULT_SELECTOR_RETRY_DELAY = 200;
 
 /**
  * NextStepReact component for rendering the onboarding steps.
@@ -44,25 +49,31 @@ import SmoothSpotlight from './SmoothSpotlight';
  *   <YourAppContent />
  * </NextStepReact>
  */
-const NextStepReact: React.FC<NextStepProps> = ({
-  children,
-  steps,
-  shadowRgb = '0, 0, 0',
-  shadowOpacity = '0.2',
-  cardTransition = { ease: 'anticipate', duration: 0.6 },
-  cardComponent: CardComponent,
-  onStart = () => {},
-  onStepChange = () => {},
-  onComplete = () => {},
-  onSkip = () => {},
-  displayArrow = true,
-  clickThroughOverlay = false,
-  navigationAdapter = useWindowAdapter,
-  disableConsoleLogs = false,
-  scrollToTop = true,
-  noInViewScroll = false,
-  overlayZIndex = 999,
-}) => {
+const NextStepReact: React.FC<NextStepProps> = (props) => {
+  const {
+    children,
+    shadowRgb = '0, 0, 0',
+    shadowOpacity = '0.2',
+    cardTransition = { ease: 'anticipate', duration: 0.6 },
+    cardComponent: CardComponent,
+    onStart = () => {},
+    onStepChange = () => {},
+    onComplete = () => {},
+    onSkip = () => {},
+    displayArrow = true,
+    clickThroughOverlay = false,
+    navigationAdapter = useWindowAdapter,
+    disableConsoleLogs = false,
+    scrollToTop = true,
+    noInViewScroll = false,
+    overlayZIndex = 999,
+    arrowComponent: ArrowComponent,
+    arrowStyle,
+  } = props;
+  // Normalize to `Tour[]` internally; the custom-card variant only differs in
+  // that its step types omit `showControls` / `showSkip` (see types/index.ts).
+  const steps: Tour[] = props.steps as Tour[];
+
   const { currentTour, currentStep, setCurrentStep, isNextStepVisible, closeNextStep } =
     useNextStep();
 
@@ -76,6 +87,11 @@ const NextStepReact: React.FC<NextStepProps> = ({
     height: number;
   } | null>(null);
   const currentElementRef = useRef<Element | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [cardDimensions, setCardDimensions] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
   const observeRef = useRef(null); // Ref for the observer element
   const isInView = useInView(observeRef);
   const offset = 20;
@@ -161,7 +177,7 @@ const NextStepReact: React.FC<NextStepProps> = ({
             const side = checkSideCutOff(
               currentTourSteps?.[currentStep]?.side || 'right',
             );
-            element.scrollIntoView({
+            scrollElementIntoViewWithOffset(element, {
               behavior: 'smooth',
               block: side.includes('top')
                 ? 'end'
@@ -234,6 +250,36 @@ const NextStepReact: React.FC<NextStepProps> = ({
   }, [currentStep, currentPath, currentTourSteps, isNextStepVisible]);
 
   // - -
+  // Scroll an element into view, honoring a per-step `scrollOffset` (clearance
+  // above/below the target, e.g. for fixed headers). Applied via `scroll-margin`
+  // so it works for both body-scroll and custom-viewport scroll containers and
+  // preserves smooth scrolling. With no `scrollOffset` it is identical to a plain
+  // `element.scrollIntoView(options)`.
+  const scrollElementIntoViewWithOffset = (
+    element: Element,
+    options: ScrollIntoViewOptions,
+  ) => {
+    const scrollOffset = currentTourSteps?.[currentStep]?.scrollOffset;
+    const el = element as HTMLElement;
+
+    if (scrollOffset && el.style) {
+      const prevMarginTop = el.style.scrollMarginTop;
+      const prevMarginBottom = el.style.scrollMarginBottom;
+      el.style.scrollMarginTop = `${scrollOffset}px`;
+      el.style.scrollMarginBottom = `${scrollOffset}px`;
+      element.scrollIntoView(options);
+      // The destination is computed synchronously at the call above, so restoring
+      // on the next frame leaves the in-flight smooth scroll untouched.
+      requestAnimationFrame(() => {
+        el.style.scrollMarginTop = prevMarginTop;
+        el.style.scrollMarginBottom = prevMarginBottom;
+      });
+    } else {
+      element.scrollIntoView(options);
+    }
+  };
+
+  // - -
   // Helper function to get element position
   const getElementPosition = (element: Element) => {
     const elementRect = element.getBoundingClientRect();
@@ -269,6 +315,9 @@ const NextStepReact: React.FC<NextStepProps> = ({
   // - -
   // Update pointerPosition when currentStep changes
   useEffect(() => {
+    let cancelled = false;
+    const retryTimers: ReturnType<typeof setTimeout>[] = [];
+
     if (isNextStepVisible && currentTourSteps) {
       if (!disableConsoleLogs) {
         console.log('NextStep: Current Step Changed');
@@ -294,8 +343,9 @@ const NextStepReact: React.FC<NextStepProps> = ({
       setScrollableParent(getScrollableParent(tempViewport));
 
       if (step && step.selector) {
-        const element = document.querySelector(step.selector) as Element | null;
-        if (element) {
+        const handleElementFound = (element: Element) => {
+          if (cancelled) return;
+
           setPointerPosition(getElementPosition(element));
           currentElementRef.current = element;
           setElementToScroll(element);
@@ -308,7 +358,7 @@ const NextStepReact: React.FC<NextStepProps> = ({
             const side = checkSideCutOff(
               currentTourSteps?.[currentStep]?.side || 'right',
             );
-            element.scrollIntoView({
+            scrollElementIntoViewWithOffset(element, {
               behavior: 'smooth',
               block: side.includes('top')
                 ? 'end'
@@ -317,7 +367,30 @@ const NextStepReact: React.FC<NextStepProps> = ({
                 : 'center',
             });
           }
-        }
+        };
+
+        // Retry the lookup for elements that render asynchronously. Defaults to a
+        // single attempt (no retry) so the original behavior is preserved.
+        const maxAttempts = Math.max(step.selectorRetryAttempts ?? 0, 0);
+        const retryDelay = step.selectorRetryDelay ?? DEFAULT_SELECTOR_RETRY_DELAY;
+
+        const attemptLookup = (remainingAttempts: number) => {
+          if (cancelled) return;
+
+          const element = document.querySelector(step.selector!) as Element | null;
+          if (element) {
+            handleElementFound(element);
+            return;
+          }
+
+          if (remainingAttempts > 0) {
+            retryTimers.push(
+              setTimeout(() => attemptLookup(remainingAttempts - 1), retryDelay),
+            );
+          }
+        };
+
+        attemptLookup(maxAttempts);
       } else {
         // Reset pointer position to middle of the screen when selector is empty, undefined, or ""
         if (step.viewportID) {
@@ -340,6 +413,12 @@ const NextStepReact: React.FC<NextStepProps> = ({
         setElementToScroll(null);
       }
     }
+
+    // Cancel any pending selector retries on step change / unmount.
+    return () => {
+      cancelled = true;
+      retryTimers.forEach((timer) => clearTimeout(timer));
+    };
   }, [currentStep, currentTourSteps, isInView, offset, isNextStepVisible]);
 
   useEffect(() => {
@@ -350,7 +429,7 @@ const NextStepReact: React.FC<NextStepProps> = ({
 
       const side = checkSideCutOff(currentTourSteps?.[currentStep]?.side || 'right');
       if (!noInViewScroll) {
-        elementToScroll.scrollIntoView({
+        scrollElementIntoViewWithOffset(elementToScroll, {
           behavior: 'smooth',
           block: side.includes('top')
             ? 'end'
@@ -458,6 +537,29 @@ const NextStepReact: React.FC<NextStepProps> = ({
       resizeObserver.disconnect();
     };
   }, [currentStep, currentTour]);
+
+  // - -
+  // Measure the rendered card so the caret can be clamped within its edges (D1).
+  useEffect(() => {
+    if (!isNextStepVisible) return;
+
+    const measure = () => {
+      const node = cardRef.current;
+      if (!node) return;
+      const { width, height } = node.getBoundingClientRect();
+      setCardDimensions((prev) =>
+        prev &&
+        Math.abs(prev.width - width) < 0.5 &&
+        Math.abs(prev.height - height) < 0.5
+          ? prev
+          : { width, height },
+      );
+    };
+
+    // Measure after layout settles (the card animates into place).
+    const raf = requestAnimationFrame(measure);
+    return () => cancelAnimationFrame(raf);
+  }, [currentStep, currentTourSteps, pointerPosition, isNextStepVisible]);
 
   // - -
   // Step Controls
@@ -600,7 +702,7 @@ const NextStepReact: React.FC<NextStepProps> = ({
           const isInViewport = top >= -offset && top <= window.innerHeight + offset;
           if (!isInViewport) {
             const side = checkSideCutOff(currentTourSteps?.[stepIndex]?.side || 'right');
-            element.scrollIntoView({
+            scrollElementIntoViewWithOffset(element, {
               behavior: 'smooth',
               block: side.includes('top')
                 ? 'end'
@@ -638,49 +740,52 @@ const NextStepReact: React.FC<NextStepProps> = ({
 
   // - -
   // Check if Card is Cut Off on Sides
+  // Flips the requested side only when the destination actually has room. If a
+  // side is cramped and its opposite is too, the placement with the most space
+  // wins instead of blindly swapping into another cut-off side (issue #69).
   const checkSideCutOff = (side: string) => {
-    if (!side) {
+    if (!side || !viewport || !pointerPosition) {
       return side;
     }
 
-    if (!viewport) {
-      return side;
-    }
+    // Space (px) the card needs to fit on a given side of the spotlight.
+    const CARD_SPACE = 256;
+    const { x, y, width, height } = pointerPosition;
+
+    // Available room around the spotlight within the (scrollable) viewport.
+    const spaceRight = viewport.scrollWidth - (x + width);
+    const spaceLeft = x;
+    const spaceTop = y;
+    const spaceBottom = viewport.scrollHeight - (y + height);
 
     let tempSide = side;
 
-    let removeSide = false;
-
-    // Check if card would be cut off on sides
-    if (
-      side.startsWith('right') &&
-      pointerPosition &&
-      viewport.scrollWidth < pointerPosition.x + pointerPosition.width + 256
-    ) {
-      removeSide = true;
-    } else if (side.startsWith('left') && pointerPosition && pointerPosition.x < 256) {
-      removeSide = true;
+    // Horizontal primary placement (left/right): flip to the opposite side only
+    // if it has room, otherwise fall back to the roomier vertical side.
+    if (side.startsWith('right') && spaceRight < CARD_SPACE) {
+      if (spaceLeft >= CARD_SPACE) {
+        tempSide = side.replace('right', 'left');
+      } else {
+        tempSide = spaceBottom >= spaceTop ? 'bottom' : 'top';
+      }
+    } else if (side.startsWith('left') && spaceLeft < CARD_SPACE) {
+      if (spaceRight >= CARD_SPACE) {
+        tempSide = side.replace('left', 'right');
+      } else {
+        tempSide = spaceBottom >= spaceTop ? 'bottom' : 'top';
+      }
     }
 
-    // Check if card would be cut off on top or bottom
-    if (side.includes('top') && pointerPosition && pointerPosition.y < 256) {
-      if (removeSide) {
-        tempSide = 'bottom';
-      } else {
-        tempSide = side.replace('top', 'bottom');
+    // Vertical placement (top/bottom): verify the destination has room before
+    // flipping; if neither side fits, keep whichever has more space.
+    if (tempSide.includes('top') && spaceTop < CARD_SPACE) {
+      if (spaceBottom >= CARD_SPACE || spaceBottom > spaceTop) {
+        tempSide = tempSide.replace('top', 'bottom');
       }
-    } else if (
-      side.includes('bottom') &&
-      pointerPosition &&
-      pointerPosition.y + pointerPosition.height + 256 > viewport.scrollHeight
-    ) {
-      if (removeSide) {
-        tempSide = 'top';
-      } else {
-        tempSide = side.replace('bottom', 'top');
+    } else if (tempSide.includes('bottom') && spaceBottom < CARD_SPACE) {
+      if (spaceTop >= CARD_SPACE || spaceTop > spaceBottom) {
+        tempSide = tempSide.replace('bottom', 'top');
       }
-    } else if (removeSide) {
-      tempSide = pointerPosition && pointerPosition.y < 256 ? 'bottom' : 'top';
     }
 
     return tempSide;
@@ -688,6 +793,7 @@ const NextStepReact: React.FC<NextStepProps> = ({
 
   // - -
   // Card Side
+  // `cardOffset` (default 25px) controls the gap between the card and the spotlight.
   const getCardStyle = (side: string): React.CSSProperties => {
     if (!side || !currentTourSteps?.[currentStep].selector) {
       // Center the card if the selector is undefined or empty
@@ -702,80 +808,83 @@ const NextStepReact: React.FC<NextStepProps> = ({
 
     side = checkSideCutOff(side);
 
+    const cardOffset = currentTourSteps?.[currentStep]?.cardOffset ?? DEFAULT_CARD_OFFSET;
+    const cardOffsetPx = `${cardOffset}px`;
+
     switch (side) {
       case 'top':
         return {
           transform: `translate(-50%, 0)`,
           left: '50%',
           bottom: '100%',
-          marginBottom: '25px',
+          marginBottom: cardOffsetPx,
         };
       case 'bottom':
         return {
           transform: `translate(-50%, 0)`,
           left: '50%',
           top: '100%',
-          marginTop: '25px',
+          marginTop: cardOffsetPx,
         };
       case 'left':
         return {
           transform: `translate(0, -50%)`,
           right: '100%',
           top: '50%',
-          marginRight: '25px',
+          marginRight: cardOffsetPx,
         };
       case 'right':
         return {
           transform: `translate(0, -50%)`,
           left: '100%',
           top: '50%',
-          marginLeft: '25px',
+          marginLeft: cardOffsetPx,
         };
       case 'top-left':
         return {
           bottom: '100%',
-          marginBottom: '25px',
+          marginBottom: cardOffsetPx,
         };
       case 'top-right':
         return {
           right: 0,
           bottom: '100%',
-          marginBottom: '25px',
+          marginBottom: cardOffsetPx,
         };
       case 'bottom-left':
         return {
           top: '100%',
-          marginTop: '25px',
+          marginTop: cardOffsetPx,
         };
       case 'bottom-right':
         return {
           right: 0,
           top: '100%',
-          marginTop: '25px',
+          marginTop: cardOffsetPx,
         };
       case 'right-bottom':
         return {
           left: '100%',
           bottom: 0,
-          marginLeft: '25px',
+          marginLeft: cardOffsetPx,
         };
       case 'right-top':
         return {
           left: '100%',
           top: 0,
-          marginLeft: '25px',
+          marginLeft: cardOffsetPx,
         };
       case 'left-bottom':
         return {
           right: '100%',
           bottom: 0,
-          marginRight: '25px',
+          marginRight: cardOffsetPx,
         };
       case 'left-top':
         return {
           right: '100%',
           top: 0,
-          marginRight: '25px',
+          marginRight: cardOffsetPx,
         };
       default:
         return {}; // Default case if no side is specified
@@ -784,81 +893,102 @@ const NextStepReact: React.FC<NextStepProps> = ({
 
   // - -
   // Arrow position based on card side
-  const getArrowStyle = (side: string) => {
+  // The perpendicular gap scales with `cardOffset` (so the caret keeps touching
+  // the card), and for corner placements the caret is centered on the anchor
+  // element rather than pinned a fixed 10px from the card corner (issue #71).
+  const getArrowStyle = (side: string): React.CSSProperties => {
     side = checkSideCutOff(side);
+
+    const cardOffset = currentTourSteps?.[currentStep]?.cardOffset ?? DEFAULT_CARD_OFFSET;
+    // -23px when cardOffset is the default 25 (behavior-preserving).
+    const arrowGap = `-${cardOffset - 2}px`;
+
+    // The spotlight (pointer box) is the target plus `pointerPadding`, centered on
+    // the target, so the anchor's center sits half a pointer box from each edge.
+    // Offsetting the caret by that half-size from the anchored card edge points it
+    // at the element's center. Clamp so it never leaves the card.
+    const halfBoxX = pointerPosition ? (pointerPosition.width + pointerPadding) / 2 : 0;
+    const halfBoxY = pointerPosition ? (pointerPosition.height + pointerPadding) / 2 : 0;
+    const CARET_EDGE = 14; // keep clear of the card's rounded corners
+    const clamp = (value: number, extent?: number) => {
+      const lower = Math.max(value, CARET_EDGE);
+      return extent ? Math.min(lower, Math.max(extent - CARET_EDGE, CARET_EDGE)) : lower;
+    };
+    const caretX = `${clamp(halfBoxX, cardDimensions?.width)}px`;
+    const caretY = `${clamp(halfBoxY, cardDimensions?.height)}px`;
 
     switch (side) {
       case 'bottom':
         return {
           transform: `translate(-50%, 0) rotate(270deg)`,
           left: '50%',
-          top: '-23px',
+          top: arrowGap,
         };
       case 'top':
         return {
           transform: `translate(-50%, 0) rotate(90deg)`,
           left: '50%',
-          bottom: '-23px',
+          bottom: arrowGap,
         };
       case 'right':
         return {
           transform: `translate(0, -50%) rotate(180deg)`,
           top: '50%',
-          left: '-23px',
+          left: arrowGap,
         };
       case 'left':
         return {
           transform: `translate(0, -50%) rotate(0deg)`,
           top: '50%',
-          right: '-23px',
+          right: arrowGap,
         };
       case 'top-left':
         return {
-          transform: `rotate(90deg)`,
-          left: '10px',
-          bottom: '-23px',
+          transform: `translate(-50%, 0) rotate(90deg)`,
+          left: caretX,
+          bottom: arrowGap,
         };
       case 'top-right':
         return {
-          transform: `rotate(90deg)`,
-          right: '10px',
-          bottom: '-23px',
+          transform: `translate(50%, 0) rotate(90deg)`,
+          right: caretX,
+          bottom: arrowGap,
         };
       case 'bottom-left':
         return {
-          transform: `rotate(270deg)`,
-          left: '10px',
-          top: '-23px',
+          transform: `translate(-50%, 0) rotate(270deg)`,
+          left: caretX,
+          top: arrowGap,
         };
       case 'bottom-right':
         return {
-          transform: `rotate(270deg)`,
-          right: '10px',
-          top: '-23px',
+          transform: `translate(50%, 0) rotate(270deg)`,
+          right: caretX,
+          top: arrowGap,
         };
       case 'right-bottom':
         return {
-          transform: `rotate(180deg)`,
-          left: '-23px',
-          bottom: '10px',
+          transform: `translate(0, 50%) rotate(180deg)`,
+          left: arrowGap,
+          bottom: caretY,
         };
       case 'right-top':
         return {
-          transform: `rotate(180deg)`,
-          left: '-23px',
-          top: '10px',
+          transform: `translate(0, -50%) rotate(180deg)`,
+          left: arrowGap,
+          top: caretY,
         };
       case 'left-bottom':
         return {
-          transform: `rotate(0deg)`,
-          right: '-23px',
-          bottom: '10px',
+          transform: `translate(0, 50%) rotate(0deg)`,
+          right: arrowGap,
+          bottom: caretY,
         };
       case 'left-top':
         return {
-          transform: `rotate(0deg)`,
-          right: '-23px',
-          top: '10px',
+          transform: `translate(0, -50%) rotate(0deg)`,
+          right: arrowGap,
+          top: caretY,
         };
       default:
         return {
@@ -873,16 +1003,39 @@ const NextStepReact: React.FC<NextStepProps> = ({
     if (!isVisible) {
       return null;
     }
+
+    const positionStyle = getArrowStyle(currentTourSteps?.[currentStep]?.side as any);
+    const resolvedSide = checkSideCutOff(
+      (currentTourSteps?.[currentStep]?.side as string) || '',
+    );
+
+    // A custom arrow component fully replaces the built-in SVG; it receives the
+    // resolved side and the computed positioning styles.
+    if (ArrowComponent) {
+      return (
+        <ArrowComponent
+          side={resolvedSide}
+          style={{
+            ...positionStyle,
+            position: 'absolute',
+            transformOrigin: 'center',
+          }}
+        />
+      );
+    }
+
     return (
       <svg
         viewBox="0 0 54 54"
         data-name="nextstep-arrow"
         style={{
-          ...getArrowStyle(currentTourSteps?.[currentStep]?.side as any),
+          ...positionStyle,
           position: 'absolute',
           width: '1.5rem',
           height: '1.5rem',
           transformOrigin: 'center',
+          // `arrowStyle` is merged last so callers can tweak color/size.
+          ...arrowStyle,
         }}
       >
         <path id="triangle" d="M27 27L0 0V54L27 27Z" fill="currentColor" />
@@ -1073,6 +1226,7 @@ const NextStepReact: React.FC<NextStepProps> = ({
             >
               {/* Card */}
               <motion.div
+                ref={cardRef}
                 data-name="nextstep-card"
                 transition={cardTransition}
                 style={{

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export type {
   Step,
   NextStepContextType,
   CardComponentProps,
+  ArrowComponentProps,
 } from './types';
 export type { NavigationAdapter } from './types/navigation';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export interface NextStepContextType {
 // Step
 export interface Step {
   // Step Content
-  icon: React.ReactNode | string | null;
+  icon?: React.ReactNode | string | null;
   title: string;
   content: React.ReactNode;
   selector?: string;
@@ -38,6 +38,32 @@ export interface Step {
   pointerPadding?: number;
   pointerRadius?: number;
   disableInteraction?: boolean;
+  /**
+   * Gap in pixels between the tour card and the spotlight highlight.
+   * The caret/arrow scales with this value too.
+   * @default 25
+   */
+  cardOffset?: number;
+  /**
+   * Extra clearance in pixels kept above (and below) the target when it is
+   * scrolled into view. Useful when a `position: fixed` / sticky header would
+   * otherwise cover the highlighted element. Honors smooth scroll and nested
+   * scroll containers (applied via `scroll-margin`).
+   * @default 0
+   */
+  scrollOffset?: number;
+  /**
+   * Number of additional attempts to locate the `selector` element when it is
+   * not present on the first lookup (useful for elements that render
+   * asynchronously). `0` preserves the original behavior (a single lookup).
+   * @default 0
+   */
+  selectorRetryAttempts?: number;
+  /**
+   * Delay in milliseconds between selector retry attempts.
+   * @default 200
+   */
+  selectorRetryDelay?: number;
   // Routing
   nextRoute?: string;
   prevRoute?: string;
@@ -52,15 +78,32 @@ export interface Tour {
   steps: Step[];
 }
 
+/**
+ * A tour whose steps omit `showControls` / `showSkip`. These options only affect
+ * the built-in `DefaultCard`, so they are meaningless when a custom
+ * `cardComponent` renders its own controls. Used by {@link NextStepPropsWithCustomCard}.
+ */
+export interface TourWithCustomCard {
+  tour: string;
+  steps: Omit<Step, 'showControls' | 'showSkip'>[];
+}
+
+/** Props passed to a custom arrow component (see `arrowComponent`). */
+export interface ArrowComponentProps {
+  /** The resolved side the card is placed on (after any cut-off adjustment). */
+  side: string;
+  /** Computed positioning styles for the arrow; spread these onto your element. */
+  style: React.CSSProperties;
+}
+
 // NextStep
-export interface NextStepProps {
+/** Provider options shared by both the default-card and custom-card variants. */
+interface NextStepCommonProps {
   children: React.ReactNode;
-  steps: Tour[];
   showNextStep?: boolean;
   shadowRgb?: string;
   shadowOpacity?: string;
   cardTransition?: Transition;
-  cardComponent?: React.ComponentType<CardComponentProps>;
   onStart?: (tourName: string | null) => void;
   onStepChange?: (step: number, tourName: string | null) => void;
   onComplete?: (tourName: string | null) => void;
@@ -72,7 +115,40 @@ export interface NextStepProps {
   scrollToTop?: boolean;
   noInViewScroll?: boolean;
   overlayZIndex?: number;
+  /**
+   * Render a fully custom arrow/caret. Receives the resolved `side` and the
+   * computed positioning `style`. When omitted, the built-in SVG arrow is used.
+   */
+  arrowComponent?: React.ComponentType<ArrowComponentProps>;
+  /**
+   * Styles merged into the built-in arrow SVG (ignored when `arrowComponent`
+   * is provided). Handy for tweaking the arrow color or size.
+   */
+  arrowStyle?: React.CSSProperties;
 }
+
+/** Provider props when using the built-in card (`showControls` / `showSkip` apply). */
+export interface NextStepPropsWithDefaultCard extends NextStepCommonProps {
+  steps: Tour[];
+  cardComponent?: never;
+}
+
+/**
+ * Provider props when a custom `cardComponent` is supplied. The custom card owns
+ * its own controls, so `showControls` / `showSkip` are stripped from step types.
+ */
+export interface NextStepPropsWithCustomCard extends NextStepCommonProps {
+  steps: TourWithCustomCard[];
+  cardComponent: React.ComponentType<CardComponentProps>;
+}
+
+/**
+ * Props for `NextStep` / `NextStepReact`. This is a discriminated union: when a
+ * `cardComponent` is provided, TypeScript drops `showControls` / `showSkip` from
+ * the step types (they only affect the built-in card). The runtime behavior is
+ * unchanged — these options are simply ignored when a custom card is used.
+ */
+export type NextStepProps = NextStepPropsWithDefaultCard | NextStepPropsWithCustomCard;
 
 // Custom Card
 export interface CardComponentProps {


### PR DESCRIPTION
## Summary

Backward-compatible improvements gathered from open issues and community PRs, shipping as **`v2.3.0-beta.0`**. Every change is opt-in with behavior-preserving defaults — no removals, no required-field changes.

### Quick DX wins
- **`Step.icon` is now optional** — no more `icon: null`. (#75)
- **`NextStepProps` is a discriminated union** — when a custom `cardComponent` is provided, `showControls` / `showSkip` are typed out of the step type (they only affect the built-in card). Runtime is unchanged; this is a type-only refinement. (#75)
- **`Step.cardOffset`** — per-step gap between the card and the spotlight; the caret scales with it. Default `25` keeps current spacing pixel-identical. Adopted from #73 (thanks @avkulikov).

### Targeting robustness
- **`Step.selectorRetryAttempts` / `selectorRetryDelay`** — retry the selector lookup for asynchronously rendered targets; timers are cancelled on step change / unmount. Default `0` preserves the single-lookup behavior. Adopted from #67 (thanks @mmabrouk); addresses #29, #52.
- **`Step.scrollOffset`** — extra clearance kept above/below the target when scrolled into view, so fixed/sticky headers stop covering it. Implemented via `scroll-margin`, so it works for body and custom-viewport scroll and preserves smooth scrolling. (#44)
- **`checkSideCutOff` room check** — verifies the destination side actually has space before flipping, otherwise falls back to the roomier side, so the card stays on-screen. (#69)

### Customization & alignment
- **`arrowComponent` / `arrowStyle`** provider props + exported **`ArrowComponentProps`** — fully replace or restyle the built-in caret. (#74)
- **Anchor-centered caret** — corner placements point the caret at the target's center instead of the card's center. (#71)

## Verification
- Public-API snapshot (`scripts/check-api.mjs`) regenerated — the only flagged change is the sanctioned `NextStepProps` interface→type refinement; everything else is additive.
- Monorepo Playwright suite green across **website (React 19)** and **remix (React 18)**, on **desktop + mobile** — a new isolated `/beta` page exercises each option (gap size, caret↔anchor center, header clearance, on-screen side-flip, async spotlight, arrow color).

## Notes
- RTL (#64) was investigated as a spike and intentionally deferred to a scoped follow-up.
- Deferred (out of scope): #72, #57, #36, #16.